### PR TITLE
Ease NumPy pinning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 fusion-blossom>=0.2.2
 jsonschema>=4.16
 matplotlib>=3.6.2
-numpy~=1.24
+numpy>=1.23
 pandas>=1.5.1
 # When bumping plotly, remember to also bump plotlyjs in docs/_static/custom.js.
 plotly>=5.11.0


### PR DESCRIPTION
Eases the NumPy pinning to allow other packages with conflicting NumPy version requirements to install.