### PR TITLE
Make sure that API docs are built before building on RTD

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,9 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
+  jobs:
+    pre_build:
+      - make -C docs apidoc
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/README.rst
+++ b/README.rst
@@ -40,8 +40,7 @@ Live pre-compiled documentation is available
 
 Alternatively, the documentation can be built from the ``master`` branch by::
 
-   cd docs
-   make clean html
+   make -C docs clean html
 
 and the build files will be available in the ``docs/_build/html`` directory.
 


### PR DESCRIPTION
During migration to RTD this step was missing. A new `pre_build` job is added such that the API docs are visible on RTD.