### PR TITLE
Fix quickstart snippet using outdated patterns

### DIFF
--- a/docs/qs_threshold.svg
+++ b/docs/qs_threshold.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-03-23T21:02:45.501074</dc:date>
+    <dc:date>2023-06-05T23:09:38.537549</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -41,12 +41,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mc071d79c81" d="M 0 0 
+       <path id="m76dc7bfe59" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc071d79c81" x="60.305455" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m76dc7bfe59" x="60.305455" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -92,7 +92,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mc071d79c81" x="127.941818" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m76dc7bfe59" x="127.941818" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -135,7 +135,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mc071d79c81" x="195.578182" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m76dc7bfe59" x="195.578182" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -167,7 +167,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mc071d79c81" x="263.214545" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m76dc7bfe59" x="263.214545" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -183,7 +183,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mc071d79c81" x="330.850909" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m76dc7bfe59" x="330.850909" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -225,7 +225,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mc071d79c81" x="398.487273" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m76dc7bfe59" x="398.487273" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -534,12 +534,12 @@ z
     <g id="ytick_1">
      <g id="line2d_7">
       <defs>
-       <path id="m40c599d33e" d="M 0 0 
+       <path id="m51be8755be" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m40c599d33e" x="57.6" y="295.488" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m51be8755be" x="57.6" y="295.488" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -554,12 +554,12 @@ L -3.5 0
     <g id="ytick_2">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m40c599d33e" x="57.6" y="245.75629" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m51be8755be" x="57.6" y="245.917999" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 0.1 -->
-      <g transform="translate(34.696875 249.555509) scale(0.1 -0.1)">
+      <g transform="translate(34.696875 249.717218) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -569,12 +569,12 @@ L -3.5 0
     <g id="ytick_3">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m40c599d33e" x="57.6" y="196.02458" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m51be8755be" x="57.6" y="196.347998" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.2 -->
-      <g transform="translate(34.696875 199.823799) scale(0.1 -0.1)">
+      <g transform="translate(34.696875 200.147217) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -584,12 +584,12 @@ L -3.5 0
     <g id="ytick_4">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m40c599d33e" x="57.6" y="146.29287" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m51be8755be" x="57.6" y="146.777997" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 0.3 -->
-      <g transform="translate(34.696875 150.092089) scale(0.1 -0.1)">
+      <g transform="translate(34.696875 150.577216) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -633,12 +633,12 @@ z
     <g id="ytick_5">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m40c599d33e" x="57.6" y="96.56116" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m51be8755be" x="57.6" y="97.207996" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 0.4 -->
-      <g transform="translate(34.696875 100.360379) scale(0.1 -0.1)">
+      <g transform="translate(34.696875 101.007215) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -669,12 +669,12 @@ z
     <g id="ytick_6">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m40c599d33e" x="57.6" y="46.82945" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m51be8755be" x="57.6" y="47.637995" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 0.5 -->
-      <g transform="translate(34.696875 50.628669) scale(0.1 -0.1)">
+      <g transform="translate(34.696875 51.437214) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-35" x="95.410156"/>
@@ -773,95 +773,55 @@ z
    </g>
    <g id="line2d_13">
     <path d="M 73.832727 295.488 
-L 90.919809 295.488 
-L 108.00689 295.488 
-L 125.093971 295.336231 
-L 142.181053 294.85057 
-L 159.268134 293.332878 
-L 176.355215 290.115373 
-L 193.442297 283.862484 
-L 210.529378 273.633245 
-L 227.616459 260.884637 
-L 244.703541 241.852788 
-L 261.790622 219.967679 
-L 278.877703 195.745325 
-L 295.964785 177.836567 
-L 313.051866 149.212908 
-L 330.138947 131.729104 
-L 347.226029 115.67193 
-L 364.31311 96.549019 
-L 381.400191 82.798735 
-L 398.487273 73.63188 
-" clip-path="url(#p8221eaf847)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5; stroke-linecap: square"/>
+L 109.905455 295.42749 
+L 145.978182 294.580346 
+L 182.050909 288.529321 
+L 218.123636 267.774303 
+L 254.196364 229.713353 
+L 290.269091 179.610861 
+L 326.341818 135.075314 
+L 362.414545 102.460286 
+L 398.487273 78.558735 
+" clip-path="url(#p66e51a106b)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5; stroke-linecap: square"/>
    </g>
    <g id="line2d_14">
     <path d="M 73.832727 295.488 
-L 90.919809 295.488 
-L 108.00689 295.488 
-L 125.093971 295.396939 
-L 142.181053 295.214816 
-L 159.268134 294.516678 
-L 176.355215 292.179433 
-L 193.442297 286.381852 
-L 210.529378 276.820396 
-L 227.616459 262.25056 
-L 244.703541 245.373832 
-L 261.790622 220.817586 
-L 278.877703 194.19728 
-L 295.964785 170.035634 
-L 313.051866 141.229852 
-L 330.138947 121.499864 
-L 347.226029 98.916617 
-L 364.31311 89.233747 
-L 381.400191 76.515493 
-L 398.487273 64.738208 
-" clip-path="url(#p8221eaf847)" style="fill: none; stroke: #ff7f0e; stroke-width: 1.5; stroke-linecap: square"/>
+L 109.905455 295.488 
+L 145.978182 295.306469 
+L 182.050909 290.465649 
+L 218.123636 272.312572 
+L 254.196364 232.496824 
+L 290.269091 180.760556 
+L 326.341818 128.540206 
+L 362.414545 88.058845 
+L 398.487273 69.784748 
+" clip-path="url(#p66e51a106b)" style="fill: none; stroke: #ff7f0e; stroke-width: 1.5; stroke-linecap: square"/>
    </g>
    <g id="line2d_15">
     <path d="M 73.832727 295.488 
-L 90.919809 295.488 
-L 108.00689 295.488 
-L 125.093971 295.488 
-L 142.181053 295.336231 
-L 159.268134 294.698801 
-L 176.355215 293.181109 
-L 193.442297 288.051312 
-L 210.529378 280.978871 
-L 227.616459 266.409034 
-L 244.703541 246.982585 
-L 261.790622 220.514048 
-L 278.877703 193.347373 
-L 295.964785 165.512913 
-L 313.051866 135.766163 
-L 330.138947 112.120532 
-L 347.226029 92.087006 
-L 364.31311 77.061862 
-L 381.400191 69.928713 
-L 398.487273 58.424612 
-" clip-path="url(#p8221eaf847)" style="fill: none; stroke: #2ca02c; stroke-width: 1.5; stroke-linecap: square"/>
+L 109.905455 295.488 
+L 145.978182 295.366979 
+L 182.050909 292.220446 
+L 218.123636 273.825329 
+L 254.196364 229.410801 
+L 290.269091 169.626669 
+L 326.341818 116.075094 
+L 362.414545 78.679756 
+L 398.487273 62.220966 
+" clip-path="url(#p66e51a106b)" style="fill: none; stroke: #2ca02c; stroke-width: 1.5; stroke-linecap: square"/>
    </g>
    <g id="line2d_16">
     <path d="M 73.832727 295.488 
-L 90.919809 295.488 
-L 108.00689 295.488 
-L 125.093971 295.488 
-L 142.181053 295.457646 
-L 159.268134 295.002339 
-L 176.355215 294.000662 
-L 193.442297 290.267142 
-L 210.529378 282.617977 
-L 227.616459 269.990785 
-L 244.703541 248.439568 
-L 261.790622 221.606785 
-L 278.877703 190.94942 
-L 295.964785 157.135257 
-L 313.051866 126.295769 
-L 330.138947 106.23189 
-L 347.226029 87.108979 
-L 364.31311 70.596497 
-L 381.400191 64.859624 
+L 109.905455 295.488 
+L 145.978182 295.245959 
+L 182.050909 292.341467 
+L 218.123636 277.940026 
+L 254.196364 229.955394 
+L 290.269091 171.018405 
+L 326.341818 109.661007 
+L 362.414545 70.20832 
 L 398.487273 53.568 
-" clip-path="url(#p8221eaf847)" style="fill: none; stroke: #d62728; stroke-width: 1.5; stroke-linecap: square"/>
+" clip-path="url(#p66e51a106b)" style="fill: none; stroke: #d62728; stroke-width: 1.5; stroke-linecap: square"/>
    </g>
    <g id="patch_3">
     <path d="M 57.6 307.584 
@@ -886,10 +846,10 @@ L 414.72 41.472
    <g id="legend_1">
     <g id="patch_7">
      <path d="M 64.6 108.1845 
-L 109.325 108.1845 
-Q 111.325 108.1845 111.325 106.1845 
-L 111.325 48.472 
-Q 111.325 46.472 109.325 46.472 
+L 133.03125 108.1845 
+Q 135.03125 108.1845 135.03125 106.1845 
+L 135.03125 48.472 
+Q 135.03125 46.472 133.03125 46.472 
 L 64.6 46.472 
 Q 62.6 46.472 62.6 48.472 
 L 62.6 106.1845 
@@ -904,10 +864,48 @@ L 86.6 54.570438
 " style="fill: none; stroke: #1f77b4; stroke-width: 1.5; stroke-linecap: square"/>
     </g>
     <g id="text_15">
-     <!-- 11 -->
+     <!-- Size 11 -->
      <g transform="translate(94.6 58.070438) scale(0.1 -0.1)">
-      <use xlink:href="#DejaVuSans-31"/>
-      <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+      <defs>
+       <path id="DejaVuSans-53" d="M 3425 4513 
+L 3425 3897 
+Q 3066 4069 2747 4153 
+Q 2428 4238 2131 4238 
+Q 1616 4238 1336 4038 
+Q 1056 3838 1056 3469 
+Q 1056 3159 1242 3001 
+Q 1428 2844 1947 2747 
+L 2328 2669 
+Q 3034 2534 3370 2195 
+Q 3706 1856 3706 1288 
+Q 3706 609 3251 259 
+Q 2797 -91 1919 -91 
+Q 1588 -91 1214 -16 
+Q 841 59 441 206 
+L 441 856 
+Q 825 641 1194 531 
+Q 1563 422 1919 422 
+Q 2459 422 2753 634 
+Q 3047 847 3047 1241 
+Q 3047 1584 2836 1778 
+Q 2625 1972 2144 2069 
+L 1759 2144 
+Q 1053 2284 737 2584 
+Q 422 2884 422 3419 
+Q 422 4038 858 4394 
+Q 1294 4750 2059 4750 
+Q 2388 4750 2728 4690 
+Q 3069 4631 3425 4513 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-53"/>
+      <use xlink:href="#DejaVuSans-69" x="63.476562"/>
+      <use xlink:href="#DejaVuSans-7a" x="91.259766"/>
+      <use xlink:href="#DejaVuSans-65" x="143.75"/>
+      <use xlink:href="#DejaVuSans-20" x="205.273438"/>
+      <use xlink:href="#DejaVuSans-31" x="237.060547"/>
+      <use xlink:href="#DejaVuSans-31" x="300.683594"/>
      </g>
     </g>
     <g id="line2d_18">
@@ -917,10 +915,15 @@ L 86.6 69.248563
 " style="fill: none; stroke: #ff7f0e; stroke-width: 1.5; stroke-linecap: square"/>
     </g>
     <g id="text_16">
-     <!-- 13 -->
+     <!-- Size 13 -->
      <g transform="translate(94.6 72.748563) scale(0.1 -0.1)">
-      <use xlink:href="#DejaVuSans-31"/>
-      <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+      <use xlink:href="#DejaVuSans-53"/>
+      <use xlink:href="#DejaVuSans-69" x="63.476562"/>
+      <use xlink:href="#DejaVuSans-7a" x="91.259766"/>
+      <use xlink:href="#DejaVuSans-65" x="143.75"/>
+      <use xlink:href="#DejaVuSans-20" x="205.273438"/>
+      <use xlink:href="#DejaVuSans-31" x="237.060547"/>
+      <use xlink:href="#DejaVuSans-33" x="300.683594"/>
      </g>
     </g>
     <g id="line2d_19">
@@ -930,10 +933,15 @@ L 86.6 83.926688
 " style="fill: none; stroke: #2ca02c; stroke-width: 1.5; stroke-linecap: square"/>
     </g>
     <g id="text_17">
-     <!-- 15 -->
+     <!-- Size 15 -->
      <g transform="translate(94.6 87.426688) scale(0.1 -0.1)">
-      <use xlink:href="#DejaVuSans-31"/>
-      <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+      <use xlink:href="#DejaVuSans-53"/>
+      <use xlink:href="#DejaVuSans-69" x="63.476562"/>
+      <use xlink:href="#DejaVuSans-7a" x="91.259766"/>
+      <use xlink:href="#DejaVuSans-65" x="143.75"/>
+      <use xlink:href="#DejaVuSans-20" x="205.273438"/>
+      <use xlink:href="#DejaVuSans-31" x="237.060547"/>
+      <use xlink:href="#DejaVuSans-35" x="300.683594"/>
      </g>
     </g>
     <g id="line2d_20">
@@ -943,7 +951,7 @@ L 86.6 98.604813
 " style="fill: none; stroke: #d62728; stroke-width: 1.5; stroke-linecap: square"/>
     </g>
     <g id="text_18">
-     <!-- 17 -->
+     <!-- Size 17 -->
      <g transform="translate(94.6 102.104813) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-37" d="M 525 4666 
@@ -957,15 +965,20 @@ L 525 4666
 z
 " transform="scale(0.015625)"/>
       </defs>
-      <use xlink:href="#DejaVuSans-31"/>
-      <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+      <use xlink:href="#DejaVuSans-53"/>
+      <use xlink:href="#DejaVuSans-69" x="63.476562"/>
+      <use xlink:href="#DejaVuSans-7a" x="91.259766"/>
+      <use xlink:href="#DejaVuSans-65" x="143.75"/>
+      <use xlink:href="#DejaVuSans-20" x="205.273438"/>
+      <use xlink:href="#DejaVuSans-31" x="237.060547"/>
+      <use xlink:href="#DejaVuSans-37" x="300.683594"/>
      </g>
     </g>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p8221eaf847">
+  <clipPath id="p66e51a106b">
    <rect x="57.6" y="41.472" width="357.12" height="266.112"/>
   </clipPath>
  </defs>

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -518,8 +518,8 @@ error rate*.
 0.038...
 
 If we combine this with changing the error rates and the size of the code, we
-can calculate the threshold of the code. We can switch to the `Stim`_ simulator
-to speed things up and calculate 1000 repetitions per data point.
+can calculate the threshold of the code. We can switch to the ``"stim"``
+backend to speed things up and calculate thousands of repetitions per data point.
 
 .. warning:: The following script will take a fairly **long** time if you run
    it sequentially! We recommend using something like
@@ -536,18 +536,18 @@ to speed things up and calculate 1000 repetitions per data point.
    import plaquette
    from plaquette.circuit.generator import generate_qec_circuit
    from plaquette.codes import LatticeCode
-   from plaquette.decoders import UnionFindDecoder
    from plaquette.device import MeasurementSample
    from plaquette.decoders.decoderbase import check_success
 
+   from plaquette_unionfind import UnionFindDecoderInterface as UnionFindDecoder
 
    plaquette.rng = np.random.default_rng(seed=1234567890)
 
    data = {}
    sizes = [11, 13, 15, 17]
-   pauli_x_rates = np.linspace(0.01, 0.25, 20)
-   logical_op = "Z"
-   reps = 2**14
+   pauli_x_rates = np.linspace(0.01, 0.25, 10)
+   logical_op = "X"
+   reps = 2**13
    for sz in sizes:
        data[sz] = {}
        code = LatticeCode.make_planar(n_rounds=1, size=sz)
@@ -560,7 +560,6 @@ to speed things up and calculate 1000 repetitions per data point.
            }
            circuit = generate_qec_circuit(code, qed, {}, logical_op)
            device = Device("stim")
-           decoder = UnionFindDecoder.from_code(code, qed, weighted=True)
            successes = 0
            for _ in range(reps):
                device.run(circuit)
@@ -568,6 +567,7 @@ to speed things up and calculate 1000 repetitions per data point.
                sample = MeasurementSample.from_code_and_raw_results(
                   code, raw_results, erasure
                )
+               decoder = UnionFindDecoder.from_code(code, qed, weighted=False)
                correction = decoder.decode(sample.erased_qubits, sample.syndrome)
                if check_success(
                    code, correction, sample.logical_op_toggle, logical_op

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -546,7 +546,7 @@ to speed things up and calculate 1000 repetitions per data point.
    data = {}
    sizes = [11, 13, 15, 17]
    pauli_x_rates = np.linspace(0.01, 0.25, 20)
-   logical_op = "X"
+   logical_op = "Z"
    reps = 2**14
    for sz in sizes:
        data[sz] = {}
@@ -560,10 +560,10 @@ to speed things up and calculate 1000 repetitions per data point.
            }
            circuit = generate_qec_circuit(code, qed, {}, logical_op)
            device = Device("stim")
-           device.run(circuit)
            decoder = UnionFindDecoder.from_code(code, qed, weighted=True)
            successes = 0
            for _ in range(reps):
+               device.run(circuit)
                raw_results, erasure = device.get_sample()
                sample = MeasurementSample.from_code_and_raw_results(
                   code, raw_results, erasure


### PR DESCRIPTION
During the update to the `Device` API, a call to `run` needs to be made before each sample, which was not happening.

- [x] fix quickstart last code snippet;
- [x] update resulting image.