### PR TITLE
Add direct support for Stim's `HERALDED_ERASE` instruction

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,6 @@ pylatexenc
 plaquette_graph
 plaquette_unionfind
 seaborn>=0.12.1
-stim>=1.10.0
+stim~=1.12
 toml>=0.10
 tqdm

--- a/src/plaquette/device/_stimsim.py
+++ b/src/plaquette/device/_stimsim.py
@@ -15,14 +15,6 @@ import plaquette
 from plaquette import circuit, device
 
 
-def _append_equiprobable(circ: stim.Circuit, p: float, steps):
-    """Helper function for adding equiprobable cases to Stim circuit."""
-    for i, step in enumerate(steps):
-        gate = ("ELSE_" if i > 0 else "") + "CORRELATED_ERROR"
-        p_i = p / (1 - i * p)
-        circ.append(gate, step, p_i)
-
-
 def circuit_to_stim(circ: circuit.Circuit) -> tuple[stim.Circuit, list[bool]]:
     """Convert Clifford circuit in ``plaquette``'s format to Stim's format.
 

--- a/src/plaquette/device/_stimsim.py
+++ b/src/plaquette/device/_stimsim.py
@@ -39,10 +39,6 @@ def circuit_to_stim(circ: circuit.Circuit) -> tuple[stim.Circuit, list[bool]]:
            whether the result signals an erasure (``True``) or a regular
            measurement outcome (:class`False`).
     """
-    n_qubits = circ.number_of_qubits
-    # One additional qubit is used to herald erasures (if necessary).
-    erasure_ancilla = n_qubits
-    x_erasure_ancilla = stim.target_x(erasure_ancilla)
     res = stim.Circuit()
     # For each measuremen result, the following list contains an entry which specifies
     # whether the result signals an erasure or a regular measurement outcome.
@@ -65,19 +61,7 @@ def circuit_to_stim(circ: circuit.Circuit) -> tuple[stim.Circuit, list[bool]]:
             case "E_ERASE":
                 assert len(args) == 2
                 p, target = args
-                # Reference: https://quantumcomputing.stackexchange.com/a/26583
-                res.append("R", erasure_ancilla)
-                _append_equiprobable(
-                    res,
-                    p / 4,
-                    (
-                        (x_erasure_ancilla, stim.target_x(target)),
-                        (x_erasure_ancilla, stim.target_y(target)),
-                        (x_erasure_ancilla, stim.target_z(target)),
-                        (x_erasure_ancilla,),
-                    ),
-                )
-                res.append("M", erasure_ancilla)
+                res.append("HERALDED_ERASE", target, p)
                 meas_is_erasure.append(True)
             case "ERROR":
                 p, name2, *args2 = args


### PR DESCRIPTION
With Stim's v1.12, the instruction `HERALDED_ERASE` has been added, making our "hack" obsolete. This PR removes the hack and uses the new instruction instead.

@antalszava could you quickly double check that this is the effective way of using the new instruction? According to the Stim's docs, "Whether or not this noise channel fires is recorded into the measurement record", so I assume there is no need to add a new `M` instruction after the erasure, but I might misinterpret things.